### PR TITLE
Fix documentation typos

### DIFF
--- a/src/Email/Html/Attributes.elm
+++ b/src/Email/Html/Attributes.elm
@@ -1,14 +1,14 @@
 module Email.Html.Attributes exposing (alt, attribute, backgroundColor, border, borderBottom, borderBottomColor, borderBottomStyle, borderBottomWidth, borderColor, borderLeft, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRight, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderTop, borderTopColor, borderWidth, color, fontFamily, fontSize, fontStyle, fontVariant, height, href, letterSpacing, lineHeight, padding, paddingBottom, paddingLeft, paddingRight, paddingTop, src, style, textAlign, verticalAlign, width)
 
-{-| Only html attributes that are supported by all major email clients are listed here.
-If you need something not that's included (and potentially not universally supported) use [`attribute`](#attribute) or [`style`](#style).
+{-| Only HTML attributes that are supported by all major email clients are listed here.
+If you need something that's not included (and potentially not universally supported) use [`attribute`](#attribute) or [`style`](#style).
 
 These sources were used to determine what should be included:
 <https://www.campaignmonitor.com/css/color-background/background/>
 <https://www.pinpointe.com/blog/email-campaign-html-and-css-support>
 <https://www.caniemail.com/>
 
-Open an issue on github if something is missing or incorrectly included.
+[Open an issue on GitHub](https://github.com/MartinSStewart/elm-email/issues/new) if something is missing or incorrectly included.
 
 
 # Attributes and styles
@@ -29,7 +29,7 @@ style =
     Internal.StyleAttribute
 
 
-{-| Use this if there's a attribute you want to add that isn't present in this module.
+{-| Use this if there's an attribute you want to add that isn't present in this module.
 Note that there's a risk that it isn't supported by some email clients.
 -}
 attribute : String -> String -> Attribute


### PR DESCRIPTION
More doc fixes.
I think it would also be a small improvement to separate `attribute` and `style` into a separate section (or at least to group them together) rather than have them be mingled with all the other attributes.
(And again, shouldn't `Attribute` be exposed?)